### PR TITLE
Added rssi to Thermostat, rssi + sabotage to binary_sensor, changed interface_id

### DIFF
--- a/components/binary_sensor/homematic.py
+++ b/components/binary_sensor/homematic.py
@@ -97,10 +97,12 @@ class HMBinarySensor(homematic.HMDevice, BinarySensorDevice):
         super().connect_to_homematic()
 
         if type(self._hmdevice).__name__ == "HMDoorContact":
+            _LOGGER.debug("Setting up HMDoorContact %s" % self._hmdevice._ADDRESS)
             self._sensor_class = 'opening'
             if self._is_available:
                 self._state = self._hmdevice.state
         elif type(self._hmdevice).__name__ == "HMRemote":
+            _LOGGER.debug("Setting up HMRemote %s" % self._hmdevice._ADDRESS)
             self._sensor_class = 'remote button'
             self._button = self._config.get('button', None)
             if not self._button:

--- a/components/homematic.py
+++ b/components/homematic.py
@@ -93,11 +93,14 @@ def setup(hass, config):
             # Connect devices already created in HA to pyhomematic and add remaining devices to list
             devices_not_created = []
             for dev in key_dict: # for dev in list(key_dict.keys()):
-                if dev in homematic_devices:
-                    for channel in homematic_devices[dev]:
-                        channel.connect_to_homematic()
-                else:
-                    devices_not_created.append(dev)
+                try:
+                    if dev in homematic_devices:
+                        for channel in homematic_devices[dev]:
+                            channel.connect_to_homematic()
+                    else:
+                        devices_not_created.append(dev)
+                except Exception as err:
+                    _LOGGER.error("Failed to setup device %s: %s" % (str(dev), str(err)))
             
             # If configuration allows auto detection of devices all devices not configured are added.         
             if autodetect and devices_not_created:

--- a/components/homematic.py
+++ b/components/homematic.py
@@ -84,7 +84,6 @@ def setup(hass, config):
 
     def system_callback_handler(src, *args):
         
-        print(src, args)
         if src == 'newDevices':
             (interface_id, dev_descriptions) = args
             key_dict = {}
@@ -109,7 +108,7 @@ def setup(hass, config):
                     ('sensor', get_sensors, DISCOVER_SENSORS),
                     ('thermostat', get_thermostats, DISCOVER_THERMOSTATS),
                     ):
-                    # Get alle devices of a specific type
+                    # Get all devices of a specific type
                     found_devices = func_get_devices(devices_not_created)
                     
                     # Devices of this type are found they are setup in HA and a event is fired
@@ -131,7 +130,12 @@ def setup(hass, config):
                         homematic_devices[dev].connect_to_homematic()
     
     # Create server thread
-    HOMEMATIC.create_server(local=local_ip, localport=local_port, remote=remote_ip, remoteport=remote_port, systemcallback=system_callback_handler) 
+    HOMEMATIC.create_server(local=local_ip,
+                            localport=local_port,
+                            remote=remote_ip,
+                            remoteport=remote_port,
+                            systemcallback=system_callback_handler,
+                            interface_id='homeassistant')
     HOMEMATIC.start() # Start server thread, connect to homegear, initialize to receive events
     # while not pyhomematic.devices or pyhomematic._server.working:
     #     time.sleep(1)

--- a/components/light/homematic.py
+++ b/components/light/homematic.py
@@ -84,6 +84,7 @@ class HMLight(homematic.HMDevice, Light):
         else:
             self._dimmer = False 
         if self._is_available:
+            _LOGGER.debug("Setting up light device %s" % self._hmdevice._ADDRESS)
             self._hmdevice.setEventCallback(event_received)
             if self._dimmer:
                 self._level = self._hmdevice.level

--- a/components/rollershutter/homematic.py
+++ b/components/rollershutter/homematic.py
@@ -85,6 +85,7 @@ class HMRollershutter(homematic.HMDevice, RollershutterDevice):
 
         super().connect_to_homematic()
         if self._is_available:
+            _LOGGER.debug("Setting up rollershutter %s" % self._hmdevice._ADDRESS)
             self._hmdevice.setEventCallback(event_received)
             self._level = self._hmdevice.level
             self.update_ha_state()

--- a/components/switch/homematic.py
+++ b/components/switch/homematic.py
@@ -70,6 +70,7 @@ class HMSwitch(homematic.HMDevice, SwitchDevice):
         else:
             self._dimmer = False 
         if self._is_available:
+            _LOGGER.debug("Setting up switch-device %s" % self._hmdevice._ADDRESS)
             self._hmdevice.setEventCallback(event_received)
             if self._dimmer:
                 self._level = self._hmdevice.level

--- a/components/thermostat/homematic.py
+++ b/components/thermostat/homematic.py
@@ -137,6 +137,7 @@ class HMThermostat(homematic.HMDevice, ThermostatDevice):
 
         super().connect_to_homematic()
         if self._is_available:
+            _LOGGER.debug("Setting up thermostat %s" % self._hmdevice._ADDRESS)
             try:
                 self._hmdevice.setEventCallback(event_received)
                 self._current_temperature = self._hmdevice.actual_temperature

--- a/components/thermostat/homematic.py
+++ b/components/thermostat/homematic.py
@@ -17,7 +17,7 @@ DEPENDENCIES = ['homematic']
 import homeassistant.components.homematic as homematic
 from homeassistant.components.thermostat import ThermostatDevice
 from homeassistant.helpers.temperature import convert
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import TEMP_CELSIUS, STATE_UNKNOWN
 
 PROPERTY_VALVE_STATE = 'VALVE_STATE'
 PROPERTY_CONTROL_MODE = 'CONTROL_MODE'
@@ -44,7 +44,8 @@ class HMThermostat(homematic.HMDevice, ThermostatDevice):
 
     def __init__(self, config):
         super().__init__(config)
-        self._battery = None
+        self._battery = STATE_UNKNOWN
+        self._rssi = STATE_UNKNOWN
 
     @property
     def unit_of_measurement(self):
@@ -88,11 +89,13 @@ class HMThermostat(homematic.HMDevice, ThermostatDevice):
         if self._is_connected:
             return {"valve": self._valve,
                     "battery": self._battery,
-                    "mode": self._mode}
+                    "mode": self._mode,
+                    "rssi": self._rssi}
         else:
-            return {"valve": None,
-                    "battery": None,
-                    "mode": None}
+            return {"valve": STATE_UNKNOWN,
+                    "battery": STATE_UNKNOWN,
+                    "mode": STATE_UNKNOWN,
+                    "rssi": STATE_UNKNOWN}
 
     @property
     def min_temp(self):
@@ -116,6 +119,8 @@ class HMThermostat(homematic.HMDevice, ThermostatDevice):
                 self._valve = float(value)
             elif attribute == 'CONTROL_MODE':
                 self._mode = value
+            elif attribute == 'RSSI_DEVICE':
+                self._rssi = value
             elif attribute == 'BATTERY_STATE':
                 if isinstance(value, float):
                     self._battery = value


### PR DESCRIPTION
Added device state attributes for Thermostat and binary_sensor (shutter contact):
- RSSI
- Sabotage

Changed interface_id to homeassistant to allow vanilla pyhomematic to be used without interface_id. Also, that's what the parameter is there for.

Now looks like this:
![bs](https://cloud.githubusercontent.com/assets/7396998/15101084/d785f952-1586-11e6-8f7c-00c83d099462.PNG)
![th](https://cloud.githubusercontent.com/assets/7396998/15101085/dac6ec7a-1586-11e6-8b0f-b95d2698057f.PNG)
